### PR TITLE
Quoting temporary paths

### DIFF
--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -2,7 +2,7 @@
 $installerType = 'MSI'
 $url = 'http://download.microsoft.com/download/B/6/D/B6D4DF81-0C26-4BA5-BD57-50B7C0935421/ApplicationVerifier.x86.msi'
 $url64 = 'http://download.microsoft.com/download/B/6/D/B6D4DF81-0C26-4BA5-BD57-50B7C0935421/ApplicationVerifier.amd64.msi'
-$silentArgs = " /l*v $env:temp\CHOCO-INSTALL-$packageName.log /qn"
+$silentArgs = " /l*v ""$env:temp\CHOCO-INSTALL-$packageName.log"" /qn"
 $validExitCodes = @(0)
 
 Install-ChocolateyPackage "$packageName" "$installerType" "$silentArgs" "$url" -validExitCodes $validExitCodes "$url64"

--- a/tools/chocolateyUninstall.ps1
+++ b/tools/chocolateyUninstall.ps1
@@ -1,8 +1,8 @@
 
 Try 
   {
-  Start-ChocolateyProcessAsAdmin "/x{134486FB-10FE-4B26-B1B6-CAB054AA7A1F} /l*v $env:temp\CHOCO-UNINSTALL-appverifier32-bit.log /qn" 'msiexec.exe' -ValidExitCodes @(0,3010,1605)
-  Start-ChocolateyProcessAsAdmin "/x{46D5EFC2-64EC-49D0-AF71-3ABDF5C61AF4} /l*v $env:temp\CHOCO-UNINSTALL-appverifier64-bit.log /qn" 'msiexec.exe' -ValidExitCodes @(0,3010,1605)
+  Start-ChocolateyProcessAsAdmin "/x{134486FB-10FE-4B26-B1B6-CAB054AA7A1F} /l*v ""$env:temp\CHOCO-UNINSTALL-appverifier32-bit.log"" /qn" 'msiexec.exe' -ValidExitCodes @(0,3010,1605)
+  Start-ChocolateyProcessAsAdmin "/x{46D5EFC2-64EC-49D0-AF71-3ABDF5C61AF4} /l*v ""$env:temp\CHOCO-UNINSTALL-appverifier64-bit.log"" /qn" 'msiexec.exe' -ValidExitCodes @(0,3010,1605)
   }
 catch {
   Write-ChocolateyFailure $package "$($_.Exception.Message)"


### PR DESCRIPTION
There is a problem with the current scripts when the temporary path contains spaces. Adding quotes fixes this behavior.